### PR TITLE
feat: EC2 IP 하드코딩 제거, 환경변수 기반으로 전환

### DIFF
--- a/src/components/IsaacSimStreamViewer.vue
+++ b/src/components/IsaacSimStreamViewer.vue
@@ -30,9 +30,9 @@ const streamInfo = ref<{ width: number; height: number; fps: number } | null>(nu
 const videoElementId = 'isaac-sim-video'
 const audioElementId = 'isaac-sim-audio'
 
-// 기본 서버 설정 (AWS EC2)
+// 서버 설정 (환경변수 또는 현재 호스트 사용)
 const serverConfig = {
-  server: props.server || '43.203.146.84',
+  server: props.server || import.meta.env.VITE_ISAAC_STREAM_SERVER || window.location.hostname,
   signalingPort: props.signalingPort || 49100,
   mediaPort: props.mediaPort || 47998
 }


### PR DESCRIPTION
## Summary
- `IsaacSimStreamViewer.vue`: AWS EC2 IP(`43.203.146.84`) 하드코딩 제거
- `VITE_ISAAC_STREAM_SERVER` 환경변수 또는 `window.location.hostname` 사용으로 전환

Closes #9

## Test plan
- [ ] 환경변수 미설정 시 window.location.hostname으로 폴백 확인
- [ ] VITE_ISAAC_STREAM_SERVER 설정 시 해당 서버로 연결 확인